### PR TITLE
Patch riscv

### DIFF
--- a/advanced/button-interrupt/exercise/Cargo.toml
+++ b/advanced/button-interrupt/exercise/Cargo.toml
@@ -24,3 +24,6 @@ esp32-c3-dkc02-bsc = { path = "../../../common/lib/esp32-c3-dkc02-bsc" }
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/advanced/button-interrupt/exercise/rust-toolchain.toml
+++ b/advanced/button-interrupt/exercise/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 
 
-channel = "nightly"
+channel = "nightly-2022-03-10"
 

--- a/advanced/button-interrupt/exercise/rust-toolchain.toml
+++ b/advanced/button-interrupt/exercise/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 
 
-channel = "nightly-2021-11-18"
+channel = "nightly"
 

--- a/advanced/button-interrupt/solution/Cargo.toml
+++ b/advanced/button-interrupt/solution/Cargo.toml
@@ -24,3 +24,6 @@ esp32-c3-dkc02-bsc = { path = "../../../common/lib/esp32-c3-dkc02-bsc" }
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/advanced/button-interrupt/solution/rust-toolchain.toml
+++ b/advanced/button-interrupt/solution/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 
 
-channel = "nightly"
+channel = "nightly-2022-03-10"
 

--- a/advanced/button-interrupt/solution/rust-toolchain.toml
+++ b/advanced/button-interrupt/solution/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 
 
-channel = "nightly-2021-11-18"
+channel = "nightly"
 

--- a/advanced/i2c-driver/solution/Cargo.toml
+++ b/advanced/i2c-driver/solution/Cargo.toml
@@ -26,3 +26,6 @@ embedded-hal = "0.2.7"
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/advanced/i2c-driver/solution/rust-toolchain.toml
+++ b/advanced/i2c-driver/solution/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 
 
-channel = "nightly"
+channel = "nightly-2022-03-10"
 

--- a/advanced/i2c-sensor-reading/solution/Cargo.toml
+++ b/advanced/i2c-sensor-reading/solution/Cargo.toml
@@ -31,3 +31,6 @@ imc42670p = { path = "../../../common/lib/imc42670p" }
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/advanced/i2c-sensor-reading/solution/rust-toolchain.toml
+++ b/advanced/i2c-sensor-reading/solution/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 
 
-channel = "nightly"
+channel = "nightly-2022-03-10"
 

--- a/book/src/02_2_software.md
+++ b/book/src/02_2_software.md
@@ -13,8 +13,8 @@ Furthermore, for ESP32-C3, a *nightly* version of the Rust toolchain is currentl
 ✅ Install nightly Rust and add support for the target architecture using the following console commands:
 
 ```console
-$ rustup install nightly-2021-11-18
-$ rustup component add rust-src --toolchain nightly-2021-11-18
+$ rustup install nightly
+$ rustup component add rust-src --toolchain nightly
 ```
 
 🔎 Rust is capable of cross-compiling to any supported target (see `rustup target list`). By default, only the native architecture of your system is installed.

--- a/book/src/03_3_2_http_client.md
+++ b/book/src/03_3_2_http_client.md
@@ -74,7 +74,6 @@ The status error can be returned with the [Anyhow](https://docs.rs/anyhow/latest
 
 ## Troubleshooting
 
-- `error: cannot find macro llvm_asm in this scope`: set `channel = "nightly-2021-11-18"` in `rust-toolchain.toml` (as of February 2022, nightly Rust and the RISC-V ecosystem are somewhat incompatible)
 - `missing WiFi name/password`: ensure that you've configured `cfg.toml` according to `cfg.toml.example` - a common problem is that package name and config section name don't match. 
 
 ```toml

--- a/book/src/03_3_3_https_client.md
+++ b/book/src/03_3_3_https_client.md
@@ -24,7 +24,6 @@ let client_config = EspHttpClientConfiguration {
 
 ## Troubleshooting (repeated from previous section)
 
-- `error: cannot find macro llvm_asm in this scope`: set `channel = "nightly-2021-11-18"` in `rust-toolchain.toml` (as of February 2022, nightly Rust and the RISC-V ecosystem are somewhat incompatible)
 - `missing WiFi name/password`: ensure that you've configured `cfg.toml` according to `cfg.toml.example` - a common problem is that package name and config section name don't match. 
 
 ```toml

--- a/common/lib/esp32-c3-dkc02-bsc/Cargo.toml
+++ b/common/lib/esp32-c3-dkc02-bsc/Cargo.toml
@@ -17,3 +17,6 @@ log = "0.4"
 anyhow = "1"
 toml-cfg = "0.1"
 riscv = { version = "0.7", features=["inline-asm"] }
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/common/lib/esp32-c3-dkc02-bsc/rust-toolchain.toml
+++ b/common/lib/esp32-c3-dkc02-bsc/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"
 

--- a/common/lib/esp32-c3-dkc02-bsc/rust-toolchain.toml
+++ b/common/lib/esp32-c3-dkc02-bsc/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"
 

--- a/common/lib/get-uuid/Cargo.toml
+++ b/common/lib/get-uuid/Cargo.toml
@@ -13,6 +13,3 @@ anyhow = "1"
 anyhow = "1"
 uuid = { version = "0.8", features = ["v4"] }
 toml = "0.5"
-
-[patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/common/lib/get-uuid/Cargo.toml
+++ b/common/lib/get-uuid/Cargo.toml
@@ -13,3 +13,6 @@ anyhow = "1"
 anyhow = "1"
 uuid = { version = "0.8", features = ["v4"] }
 toml = "0.5"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/common/lib/imc42670p/Cargo.toml
+++ b/common/lib/imc42670p/Cargo.toml
@@ -9,6 +9,3 @@ edition = "2021"
 
 [dependencies]
 embedded-hal = "0.2.7"
-
-[patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/common/lib/imc42670p/Cargo.toml
+++ b/common/lib/imc42670p/Cargo.toml
@@ -10,3 +10,5 @@ edition = "2021"
 [dependencies]
 embedded-hal = "0.2.7"
 
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/common/lib/mqtt-messages/Cargo.toml
+++ b/common/lib/mqtt-messages/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 rgb = "0.8"
 
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/common/lib/mqtt-messages/Cargo.toml
+++ b/common/lib/mqtt-messages/Cargo.toml
@@ -8,5 +8,3 @@ edition = "2021"
 [dependencies]
 rgb = "0.8"
 
-[patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/hardware-check/Cargo.toml
+++ b/intro/hardware-check/Cargo.toml
@@ -26,3 +26,6 @@ toml-cfg = "0.1"
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/hardware-check/rust-toolchain.toml
+++ b/intro/hardware-check/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"

--- a/intro/hardware-check/rust-toolchain.toml
+++ b/intro/hardware-check/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"

--- a/intro/http-client/exercise/Cargo.toml
+++ b/intro/http-client/exercise/Cargo.toml
@@ -27,3 +27,6 @@ toml-cfg = "0.1"
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/http-client/exercise/rust-toolchain.toml
+++ b/intro/http-client/exercise/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"

--- a/intro/http-client/exercise/rust-toolchain.toml
+++ b/intro/http-client/exercise/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"

--- a/intro/http-client/solution/Cargo.toml
+++ b/intro/http-client/solution/Cargo.toml
@@ -27,3 +27,6 @@ toml-cfg = "0.1"
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/http-client/solution/rust-toolchain.toml
+++ b/intro/http-client/solution/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"

--- a/intro/http-client/solution/rust-toolchain.toml
+++ b/intro/http-client/solution/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"

--- a/intro/http-server/exercise/Cargo.toml
+++ b/intro/http-server/exercise/Cargo.toml
@@ -28,3 +28,6 @@ toml-cfg = "0.1"
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/http-server/exercise/rust-toolchain.toml
+++ b/intro/http-server/exercise/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"

--- a/intro/http-server/exercise/rust-toolchain.toml
+++ b/intro/http-server/exercise/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"

--- a/intro/http-server/solution/Cargo.toml
+++ b/intro/http-server/solution/Cargo.toml
@@ -28,3 +28,6 @@ toml-cfg = "0.1"
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/http-server/solution/rust-toolchain.toml
+++ b/intro/http-server/solution/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"

--- a/intro/http-server/solution/rust-toolchain.toml
+++ b/intro/http-server/solution/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"

--- a/intro/mqtt/exercise/Cargo.toml
+++ b/intro/mqtt/exercise/Cargo.toml
@@ -33,3 +33,6 @@ mqtt-messages = { path = "../../../common/lib/mqtt-messages" }
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/mqtt/exercise/rust-toolchain.toml
+++ b/intro/mqtt/exercise/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"
 

--- a/intro/mqtt/exercise/rust-toolchain.toml
+++ b/intro/mqtt/exercise/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"
 

--- a/intro/mqtt/host-client/Cargo.toml
+++ b/intro/mqtt/host-client/Cargo.toml
@@ -11,3 +11,6 @@ rand = "0.8.4"
 toml-cfg = "0.1"
 get-uuid = { path = "../../../common/lib/get-uuid" }
 mqtt-messages = { path = "../../../common/lib/mqtt-messages" }
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/mqtt/host-client/Cargo.toml
+++ b/intro/mqtt/host-client/Cargo.toml
@@ -12,5 +12,3 @@ toml-cfg = "0.1"
 get-uuid = { path = "../../../common/lib/get-uuid" }
 mqtt-messages = { path = "../../../common/lib/mqtt-messages" }
 
-[patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/mqtt/solution/Cargo.toml
+++ b/intro/mqtt/solution/Cargo.toml
@@ -33,3 +33,6 @@ mqtt-messages = { path = "../../../common/lib/mqtt-messages" }
 [build-dependencies]
 embuild = "0.28"
 anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}

--- a/intro/mqtt/solution/rust-toolchain.toml
+++ b/intro/mqtt/solution/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-11-18"
+channel = "nightly"
 

--- a/intro/mqtt/solution/rust-toolchain.toml
+++ b/intro/mqtt/solution/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-03-10"
 


### PR DESCRIPTION
Currently does not build
```
 ➜  hardware-check git:(patch_riscv) ✗ cargo build --target riscv32imc-esp-espidf                

   Compiling compiler_builtins v0.1.70
   Compiling libc v0.2.116
   Compiling ring v0.16.20
   Compiling url v2.2.2
   Compiling globset v0.4.8
   Compiling env_logger v0.9.0
   Compiling darling_core v0.13.1
   Compiling riscv-target v0.1.2
error: no rules expected the token `aarch64_apple`
   --> /Users/brigitte/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/src/cpu.rs:257:13
    |
165 |     macro_rules! features {
    |     --------------------- when calling this macro
...
257 |             aarch64_apple: true,
    |             ^^^^^^^^^^^^^ no rules expected this token in macro call

error[E0425]: cannot find value `AES` in module `cpu::arm`
   --> /Users/brigitte/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/src/aead/aes.rs:381:65
    |
381 |         if cpu::intel::AES.available(cpu_features) || cpu::arm::AES.available(cpu_features) {
    |                                                                 ^^^ not found in `cpu::arm`
    |
help: consider importing this constant
    |
15  | use crate::cpu::intel::AES;
    |

error[E0425]: cannot find value `PMULL` in module `cpu::arm`
   --> /Users/brigitte/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/src/aead/gcm.rs:315:26
    |
315 |             || cpu::arm::PMULL.available(cpu_features)
    |                          ^^^^^ not found in `cpu::arm`

error[E0425]: cannot find value `ARMCAP_STATIC` in this scope
   --> /Users/brigitte/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/src/cpu.rs:235:41
    |
235 |             if self.mask == self.mask & ARMCAP_STATIC {
    |                                         ^^^^^^^^^^^^^ not found in this scope

   Compiling async-trait v0.1.52
   Compiling serde v1.0.136
For more information about this error, try `rustc --explain E0425`.
error: could not compile `ring` due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```