### PR TITLE
Updates resulting from testing the ESP-RS board

### DIFF
--- a/advanced/i2c-driver/solution/src/main.rs
+++ b/advanced/i2c-driver/solution/src/main.rs
@@ -14,8 +14,8 @@ fn main() -> anyhow::Result<()> {
 
     let peripherals = Peripherals::take().unwrap();
 
-    let sda = peripherals.pins.gpio4;
-    let scl = peripherals.pins.gpio5;
+    let sda = peripherals.pins.gpio10;
+    let scl = peripherals.pins.gpio8;
 
     let i2c = Master::<I2C0, _, _>::new(
         peripherals.i2c0,
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
         <MasterConfig as Default>::default().baudrate(400.kHz().into()),
     )?;
 
-    let mut sensor = IMC42670P::new(i2c, SlaveAddr::AD1)?;
+    let mut sensor = IMC42670P::new(i2c, SlaveAddr::AD0)?;
     println!("Sensor init");
     let device_id = sensor.read_device_id_register()?;
 

--- a/advanced/i2c-driver/solution/src/main.rs
+++ b/advanced/i2c-driver/solution/src/main.rs
@@ -16,6 +16,9 @@ fn main() -> anyhow::Result<()> {
 
     let sda = peripherals.pins.gpio10;
     let scl = peripherals.pins.gpio8;
+    // If you are using an ESP32-C3-DevKitC-02, change to:
+    // let sda = peripherals.pins.gpio4;
+    // let scl = peripherals.pins.gpio5;
 
     let i2c = Master::<I2C0, _, _>::new(
         peripherals.i2c0,
@@ -24,6 +27,8 @@ fn main() -> anyhow::Result<()> {
     )?;
 
     let mut sensor = IMC42670P::new(i2c, SlaveAddr::AD0)?;
+    // If you are using an ESP32-C3-DevKitC-02, change to:
+    // let mut sensor = IMC42670P::new(i2c, SlaveAddr::AD1)?;
     println!("Sensor init");
     let device_id = sensor.read_device_id_register()?;
 

--- a/advanced/i2c-sensor-reading/solution/src/main.rs
+++ b/advanced/i2c-sensor-reading/solution/src/main.rs
@@ -10,7 +10,6 @@ use esp_idf_sys::*;
 
 use shtcx::{self, PowerMode};
 
-
 // goals of this exercise:
 // instantiate i2c peripheral
 // implement one sensor, print sensor values
@@ -23,6 +22,9 @@ fn main() -> anyhow::Result<()>  {
 
     let sda = peripherals.pins.gpio10;
     let scl = peripherals.pins.gpio8;
+    // If you are using an ESP32-C3-DevKitC-02, change to:
+    // let sda = peripherals.pins.gpio4;
+    // let scl = peripherals.pins.gpio5;
 
     let i2c = Master::<I2C0, _, _>::new(
         peripherals.i2c0,

--- a/advanced/i2c-sensor-reading/solution/src/main.rs
+++ b/advanced/i2c-sensor-reading/solution/src/main.rs
@@ -7,11 +7,9 @@ use esp_idf_hal::{
     prelude::*,
 };
 use esp_idf_sys::*;
-use imc42670p::{IMC42670P, SlaveAddr};
 
 use shtcx::{self, PowerMode};
 
-use shared_bus;
 
 // goals of this exercise:
 // instantiate i2c peripheral
@@ -23,8 +21,8 @@ fn main() -> anyhow::Result<()>  {
 
     let peripherals = Peripherals::take().unwrap();
 
-    let sda = peripherals.pins.gpio4;
-    let scl = peripherals.pins.gpio5;
+    let sda = peripherals.pins.gpio10;
+    let scl = peripherals.pins.gpio8;
 
     let i2c = Master::<I2C0, _, _>::new(
         peripherals.i2c0,

--- a/advanced/i2c-sensor-reading/solution/src/main_both.rs
+++ b/advanced/i2c-sensor-reading/solution/src/main_both.rs
@@ -23,8 +23,8 @@ fn main() -> anyhow::Result<()>  {
 
     let peripherals = Peripherals::take().unwrap();
 
-    let sda = peripherals.pins.gpio4;
-    let scl = peripherals.pins.gpio5;
+    let sda = peripherals.pins.gpio10;
+    let scl = peripherals.pins.gpio8;
 
     let i2c = Master::<I2C0, _, _>::new(
         peripherals.i2c0,
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()>  {
     let proxy_1 =bus.acquire_i2c();
     let proxy_2 =bus.acquire_i2c();
 
-    let mut imu = IMC42670P::new(proxy_1, SlaveAddr::B110_1001)?;
+    let mut imu = IMC42670P::new(proxy_1, SlaveAddr::B110_1000)?;
     println!("Sensor init");
     let device_id = imu.read_device_id_register()?;
     println!("Device ID: {}", device_id);

--- a/advanced/i2c-sensor-reading/solution/src/main_both.rs
+++ b/advanced/i2c-sensor-reading/solution/src/main_both.rs
@@ -25,6 +25,9 @@ fn main() -> anyhow::Result<()>  {
 
     let sda = peripherals.pins.gpio10;
     let scl = peripherals.pins.gpio8;
+    // If you are using an ESP32-C3-DevKitC-02, change to:
+    // let sda = peripherals.pins.gpio4;
+    // let scl = peripherals.pins.gpio5;
 
     let i2c = Master::<I2C0, _, _>::new(
         peripherals.i2c0,
@@ -38,6 +41,8 @@ fn main() -> anyhow::Result<()>  {
     let proxy_2 =bus.acquire_i2c();
 
     let mut imu = IMC42670P::new(proxy_1, SlaveAddr::B110_1000)?;
+    // If you are using an ESP32-C3-DevKitC-02, change to:
+    // let mut imu = IMC42670P::new(proxy_1, SlaveAddr::B110_1001)?;
     println!("Sensor init");
     let device_id = imu.read_device_id_register()?;
     println!("Device ID: {}", device_id);

--- a/book/src/01_intro.md
+++ b/book/src/01_intro.md
@@ -4,7 +4,11 @@ This is Ferrous Systems' *Embedded Rust on Espressif* training material. It is d
 
 The advanced course takes it from there to dive deeper into topics like interrupt handling, low-level peripheral access and writing your own drivers.
 
+<<<<<<< HEAD
 An [Espressif Rust Board]([https://](https://github.com/esp-rs/esp-rust-board)) or [ESP32-C3-DevKitC-02](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitc-02.html) (intro part only!) is mandatory for working with this book - emulators like QEMU are not supported. Some exercises also require wireless internet access.
+=======
+An [Espressif Rust Board](https://github.com/esp-rs/esp-rust-board) - to be released soon - or [ESP32-C3-DevKitC-02](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitc-02.html) (intro part only!) is mandatory for working with this book - emulators like QEMU are not supported. Some exercises also require wireless internet access.
+>>>>>>> 4634d20 (Fix broken link to ESP-RS board, make a remark about it not being released yet.)
 
 Our focus lies primarily on the [ESP32-C3](https://www.espressif.com/en/products/socs/esp32-c3) platform, a [RISC-V](https://riscv.org/) based microcontroller with strong IoT capabilities, facilitated by integrated Wi-Fi and Bluetooth 5 (LE) functionality as well as large RAM + flash size for sophisticated applications. A substantial amount of this course is also applicable for Xtensa the other architecture Espressif uses, in particular the [ESP32-S3](https://www.espressif.com/en/products/socs/esp32-s3). For low-level access the general principles apply as well, but actual hardware access will differ in various ways - refer to the technical reference manuals ([C3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf), [S3](https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf)) or [other available technical documents](https://www.espressif.com/en/support/documents/technical-documents)  as needed.
 

--- a/book/src/02_0_preparations.md
+++ b/book/src/02_0_preparations.md
@@ -25,6 +25,7 @@ No additional debugger/probe hardware is required.
 
 ❗️ If you are participating in a training led by Ferrous Systems, we urge you to do prepare for the workshop by following the instructions in this chapter least one business day in advance to verify you're ready to go by the time it starts. Please [contact us](training@ferrous-systems.com) should you encounter any issues or require any kind of support.
 
+❗️ If you are using a [ESP32-C3-DevKitC-02](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitc-02.html) a few pins and slave adresses are different, since the board is similar but not the same. This is relevant for the solutions in [advanced/i2c-sensor-reading/](/advanced/i2c-sensor-reading/solution/src/) and [advanced/i2c-driver/](/advanced/i2c-driver/solution/src/), where the pins and slave addresses for the ESP32-C3-DevKitC-02 are commented out.
 
 ## Companion material
 

--- a/book/src/02_1_hardware.md
+++ b/book/src/02_1_hardware.md
@@ -13,12 +13,14 @@ $ lsusb | grep UART
 Bus 001 Device 011: ID 10c4:ea60 Silicon Laboratories, Inc. CP2102N USB to UART Bridge Controller  Serial: a4c4193ceaa0eb119085d1acdf749906
 ```
 
-The device will also show up in the `/dev` directory as a `ttyUSB` device:
+The device will also show up in the `/dev` directory as a `tty.usbmodem` device:
 
 ``` console
-$ ls /dev/ttyUSB*
-/dev/ttyUSB0
+$ ls /dev/tty.usbmodem*
+/dev/tty.usbmodem0
 ```
+
+(If you are using a ESP32-C3-DevKitC-02 the command is `$ ls /dev/ttyUSB*` )
 
 **macOS**:
 
@@ -26,20 +28,11 @@ The device will show up as part of the USB tree in `system_profiler`:
 
 ```console
 
-$ system_profiler SPUSBDataType | grep -A 11 "USB to UART"
+$ system_profiler SPUSBDataType | grep -A 11 "USB JTAG"
 
-CP2102N USB to UART Bridge Controller:
+USB JTAG/serial debug unit:
 
-  Product ID: 0xea60
-  Vendor ID: 0x10c4  (Silicon Laboratories, Inc.)
+  Product ID: 0x1001
+  Vendor ID: 0x303a
   (...)
 ```
-
-The device will also show up in the `/dev` directory as `tty.usbserial<XXXX>`
-
-```console
-$ ls /dev/tty.usbserial*
-/dev/tty.usbserial-114430
-
-```
-

--- a/book/src/02_2_software.md
+++ b/book/src/02_2_software.md
@@ -13,7 +13,11 @@ Furthermore, for ESP32-C3, a specific *nightly* version of the Rust toolchain is
 ✅ Install nightly Rust and add support for the target architecture using the following console commands:
 
 ```console
+<<<<<<< HEAD
 $ rustup install nightly nightly-2022-03-10
+=======
+$ rustup install nightly-2022-03-10
+>>>>>>> 2d9c800 (Explicitly install nightly-2022-03-10.)
 $ rustup component add rust-src --toolchain nightly-2022-03-10
 ```
 

--- a/book/src/03_2_cargo_generate.md
+++ b/book/src/03_2_cargo_generate.md
@@ -56,6 +56,14 @@ Optional, but recommended: To save disk space and download time, set the toolcha
 ESP_IDF_TOOLS_INSTALL_DIR = { value = "global" } # add this line
 ```
 
+✅ Open `hello-world/rust-toolchain.toml` and change the file to look like this:
+
+```toml
+[toolchain]
+
+channel = "nightly-2022-03-10" # change this line
+```
+
 ✅ Run your project by using the following command out of the `hello_world` directory.
 
 ```shell

--- a/book/src/03_5_3_mqtt.md
+++ b/book/src/03_5_3_mqtt.md
@@ -122,7 +122,7 @@ match message.details() {
 #### Hints!
 
 - Since you will be iterating over a MQTT topic, you will need to `split()` on a string returns an iterator. You can access a specific item from an iterator using [`nth()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.nth).
-- The solution implementing hierarchy can be run with `cargo espflash --release --example solution2 --monitor /dev/ttyUSB0`, while the solution without can be run with `cargo espflash --release --monitor /dev/ttyUSB0` or `cargo espflash --release --example solution1 --monitor /dev/ttyUSB0`
+- The solution implementing hierarchy can be run with `cargo espflash --release --example solution2 --monitor /dev/tty.usbmodem0`, while the solution without can be run with `cargo espflash --release --monitor /dev/tty.usbmodem0` or `cargo espflash --release --example solution1 --monitor /dev/tty.usbmodem0`
 
 ### Other tasks
 

--- a/book/src/04_0_advanced_workshop.md
+++ b/book/src/04_0_advanced_workshop.md
@@ -8,7 +8,7 @@ In this course we're going to dive deeper into topics that are embedded-only and
 
  ## Preparations
  
- Please go through the [preparations](./02_preparations.md) chapter to prepare for this workshop.
+ Please go through the [preparations](./02_0_preparations.md) chapter to prepare for this workshop.
 
  ## Reference
 

--- a/book/src/04_2_low_level_io.md
+++ b/book/src/04_2_low_level_io.md
@@ -29,11 +29,11 @@ In Rust the mapping from Registers to Code works like this:
 
 Registers and their fields on a device are described in _System View Description_ (SVD) files. `svd2rust` is used to generate _Peripheral Access Crates_ (PACs) from these SVD files. The PACs provide a thin wrapper over the various memory-mapped registers defined for the particular model of micro-controller you are using.
 
-Whilst it is possible to write firmware with a PAC alone, some of it would unsafe or otherwise inconvenient as it only provides the most basic access to the peripherals of the microcontroller. So there is another layer, the _Hardware Abstraction Layer_ (HAL). HALs provide a more user friendly API for the chip, and often implement common traits defined in the generic [`embedded-hal`](https://github.com/rust-embedded/embedded-hal).
+Whilst it is possible to write firmware with a PAC alone, some of it would prove unsafe or otherwise inconvenient as it only provides the most basic access to the peripherals of the microcontroller. So there is another layer, the _Hardware Abstraction Layer_ (HAL). HALs provide a more user friendly API for the chip, and often implement common traits defined in the generic [`embedded-hal`](https://github.com/rust-embedded/embedded-hal).
 
-Microcontrollers are usually soldered to some _Printed Circuit Board_ (or just _Board_), which defines the connections that are made to each pin. A _Board Support Crate_ (BSC, also known as a _Board Support Package_ or BSP) may be written for a given board. This provide yet another layer of abstraction and might, for example, provide an API to the various sensors and LEDs on that board - without the user necessarily needing to know which pins on your microcontroller are connected to those sensors or LEDs. 
+Microcontrollers are usually soldered to some _Printed Circuit Board_ (or just _Board_), which defines the connections that are made to each pin. A _Board Support Crate_ (BSC, also known as a _Board Support Package_ or BSP) may be written for a given board. This provides yet another layer of abstraction and might, for example, provide an API to the various sensors and LEDs on that board - without the user necessarily needing to know which pins on your microcontroller are connected to those sensors or LEDs.
 
-Although a [PAC](https://github.com/esp-rs/esp32c3) for the ESP32-C3 exists, bare-metal Rust is highly experimental on ESP32-C3 chips, so for now we will not work with it on the microcontroller directly. We will write a partial sensor driver in this approach as driver's should be platform agnostic. 
+Although a [PAC](https://github.com/esp-rs/esp-pacs/tree/main/esp32c3) for the ESP32-C3 exists, bare-metal Rust is highly experimental on ESP32-C3 chips, so for now we will not work with it on the microcontroller directly. We will write a partial sensor driver in this approach as driver's should be platform agnostic.
 
 
 

--- a/common/lib/esp32-c3-dkc02-bsc/src/led.rs
+++ b/common/lib/esp32-c3-dkc02-bsc/src/led.rs
@@ -106,7 +106,7 @@ impl WS2812RMT {
         let config = rmt_config_t {
             rmt_mode: rmt_mode_t_RMT_MODE_TX,
             channel: 0,
-            gpio_num: 8,
+            gpio_num: 7,
             clk_div: 2,
             mem_block_num: 1,
             flags: 0,
@@ -142,7 +142,7 @@ impl WS2812RMT {
             esp!(rmt_write_sample(
                 self.config.channel,
                 &[color.g, color.r, color.b] as *const u8, // WS2812 expects GRB, not RGB
-                3,
+                1000,
                 true,
             ))?;
             esp!(rmt_wait_tx_done(

--- a/common/lib/esp32-c3-dkc02-bsc/src/led.rs
+++ b/common/lib/esp32-c3-dkc02-bsc/src/led.rs
@@ -142,7 +142,7 @@ impl WS2812RMT {
             esp!(rmt_write_sample(
                 self.config.channel,
                 &[color.g, color.r, color.b] as *const u8, // WS2812 expects GRB, not RGB
-                1000,
+                3,
                 true,
             ))?;
             esp!(rmt_wait_tx_done(

--- a/intro/mqtt/exercise/cfg.toml.example
+++ b/intro/mqtt/exercise/cfg.toml.example
@@ -4,3 +4,11 @@ mqtt_pass = "CorrectHorseBatteryStaple"
 mqtt_host = "yourpc.local"
 wifi_ssid = "FBI Surveillance Van"
 wifi_psk = "hunter2"
+
+# If you're participating in a Ferrous Systems training, 
+# login credentials for a server operated by Espressif 
+# will be made available in the workshop.
+
+# If you are working on your own you could use one listed at https://test.mosquitto.org/,
+# e.g. the simplest way is to just place `mqtt_host = "test.mosquitto.org"` (and remove the other mqtt keys but leave the wifi ones).
+

--- a/intro/mqtt/host-client/cfg.toml.example
+++ b/intro/mqtt/host-client/cfg.toml.example
@@ -2,3 +2,10 @@
 mqtt_user = "horse"
 mqtt_pass = "CorrectHorseBatteryStaple"
 mqtt_host = "yourpc.local"
+
+# If you're participating in a Ferrous Systems training, 
+# login credentials for a server operated by Espressif 
+# will be made available in the workshop.
+
+# If you are working on your own you could use one listed at https://test.mosquitto.org/,
+# e.g. the simplest way is to just place `mqtt_host = "test.mosquitto.org"` (and remove the other keys).


### PR DESCRIPTION
This PR changes the workshop material to be explicitly for the ESP-RS board. 
(It is still possible to use the ESP32-C3-DevKitC-02. To run some of the solutions in the i2c folders it is necessary to uncomment / comment out some pins and slave addresses.)