### PR TITLE
Use `rev` option to set fixed commit hash

### DIFF
--- a/advanced/button-interrupt/exercise/Cargo.toml
+++ b/advanced/button-interrupt/exercise/Cargo.toml
@@ -26,4 +26,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/advanced/button-interrupt/solution/Cargo.toml
+++ b/advanced/button-interrupt/solution/Cargo.toml
@@ -26,4 +26,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/advanced/i2c-driver/solution/Cargo.toml
+++ b/advanced/i2c-driver/solution/Cargo.toml
@@ -28,4 +28,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/advanced/i2c-sensor-reading/solution/Cargo.toml
+++ b/advanced/i2c-sensor-reading/solution/Cargo.toml
@@ -33,4 +33,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/common/lib/esp32-c3-dkc02-bsc/Cargo.toml
+++ b/common/lib/esp32-c3-dkc02-bsc/Cargo.toml
@@ -19,4 +19,4 @@ toml-cfg = "0.1"
 riscv = { version = "0.7", features=["inline-asm"] }
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/hardware-check/Cargo.toml
+++ b/intro/hardware-check/Cargo.toml
@@ -28,4 +28,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/http-client/exercise/Cargo.toml
+++ b/intro/http-client/exercise/Cargo.toml
@@ -29,4 +29,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/http-client/solution/Cargo.toml
+++ b/intro/http-client/solution/Cargo.toml
@@ -29,4 +29,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/http-server/exercise/Cargo.toml
+++ b/intro/http-server/exercise/Cargo.toml
@@ -30,4 +30,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/http-server/solution/Cargo.toml
+++ b/intro/http-server/solution/Cargo.toml
@@ -30,4 +30,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/mqtt/exercise/Cargo.toml
+++ b/intro/mqtt/exercise/Cargo.toml
@@ -35,4 +35,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/intro/mqtt/solution/Cargo.toml
+++ b/intro/mqtt/solution/Cargo.toml
@@ -35,4 +35,4 @@ embuild = "0.28"
 anyhow = "1"
 
 [patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master"}
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}


### PR DESCRIPTION
This change sets a fixed commit revision to the `riscv` patch annotation in all `Cargo.toml` files.

Using `master` as a `branch` option resulted in different commit hashes at different times, which occurred due to changes in the [`riscv` crate](https://github.com/rust-embedded/riscv). This crate has seen some changes in the last days / weeks that broke the current setup, therefore a working revision is set.

All examples compiled successfully but have not been tested with the hardware itself.

This should fix #55.