### PR TITLE
Add Github CI pipeline to check code

### DIFF
--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ef
+
+WORK_DIR=$HOME/workspace
+
+echo "Compiling all exercises & library crates"
+for file in $(find ${WORK_DIR} -name "Cargo.toml")
+do
+    cd $(dirname $file)
+    echo "Checking $(pwd)"
+    $HOME/.cargo/bin/cargo clean
+    $HOME/.cargo/bin/cargo build
+done

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,8 +2,16 @@
 name: Build Docker Image
 
 on:
+  pull_request:
+    paths:
+      - '!book/**'
+    branches:
+      - main
   push:
-    branches: [main]
+    paths:
+      - '!book/**'
+    branches:
+      - main
 
 jobs:
   # To avoid uploading the Docker image to a registry yet
@@ -19,4 +27,6 @@ jobs:
         run: docker image build --tag esp --file .devcontainer/Dockerfile .
 
       - name: Test code examples in Docker image
-        run: docker run --user esp --mount type=bind,source="$(pwd)",target=/home/esp/workspace,consistency=cached --rm -it esp:latest /bin/bash /home/esp/workspace/.devcontainer/test.sh
+        run: |
+          docker run --user esp --mount type=bind,source="$(pwd)",target=/home/esp/workspace,consistency=cached \
+                 --rm -it esp:latest /bin/bash /home/esp/workspace/.devcontainer/test.sh

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,22 @@
+---
+name: Build Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # To avoid uploading the Docker image to a registry yet
+  # the image is built here & immediately used to test all exercises in.
+  # TODO at a later point split that into separate jobs
+  build_image_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: docker image build --tag esp --file .devcontainer/Dockerfile .
+
+      - name: Test code examples in Docker image
+        run: docker run --user esp --mount type=bind,source="$(pwd)",target=/home/esp/workspace,consistency=cached --rm -it esp:latest /bin/bash /home/esp/workspace/.devcontainer/test.sh


### PR DESCRIPTION
This PR adds a Github CI workflow to build the Docker image from the `Dockerfile` in folder `.devcontainer`. It uses the resulting Docker image to compile all Rust libraries & exercises in this repository. 