### PR TITLE
Fix CI pipeline & devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,6 @@ FROM debian:bullseye-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-ARG CONTAINER_USER=esp
 ARG NIGHTLY_VERSION=nightly-2022-03-10
 ARG ESP_IDF_VERSION=release/v4.4
 ARG ESP_BOARD=esp32c3
@@ -23,7 +22,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
     && $HOME/.cargo/bin/rustup component add rust-src --toolchain ${NIGHTLY_VERSION} \
     && $HOME/.cargo/bin/rustup target add riscv32i-unknown-none-elf
 
-RUN $HOME/.cargo/bin/cargo install cargo-espflash espmonitor bindgen ldproxy
+RUN $HOME/.cargo/bin/cargo install cargo-espflash espmonitor ldproxy
 
 RUN mkdir -p .espressif/frameworks/ \
     && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \
@@ -37,7 +36,7 @@ RUN mkdir -p .espressif/frameworks/ \
     && rm -rf .espressif/frameworks/esp-idf-v4.4/tools/esp_app_trace \
     && rm -rf .espressif/frameworks/esp-idf-v4.4/tools/test_idf_size
 
-ENV IDF_TOOLS_PATH=/home/${CONTAINER_USER}/.espressif
-RUN echo "source /home/${CONTAINER_USER}/.espressif/frameworks/esp-idf-v4.4/export.sh > /dev/null 2>&1" >> ~/.bashrc
+ENV IDF_TOOLS_PATH=/root/.espressif
+RUN echo "source /root/.espressif/frameworks/esp-idf-v4.4/export.sh > /dev/null 2>&1" >> ~/.bashrc
 
 CMD "/bin/bash"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
+# There are a few Dockerfile restrictions when using Github Actions
+# See: https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions
+
 FROM debian:bullseye-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ARG CONTAINER_USER=esp
-ARG CONTAINER_GROUP=esp
 ARG NIGHTLY_VERSION=nightly-2022-03-10
 ARG ESP_IDF_VERSION=release/v4.4
 ARG ESP_BOARD=esp32c3
@@ -14,9 +16,6 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
-RUN adduser --disabled-password --gecos "" ${CONTAINER_USER}
-USER ${CONTAINER_USER}
-WORKDIR /home/${CONTAINER_USER}
 ENV PATH=${PATH}:$HOME/.cargo/bin
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,23 +1,29 @@
-FROM debian:bullseye
+FROM debian:bullseye-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ARG CONTAINER_USER=esp
 ARG CONTAINER_GROUP=esp
 ARG NIGHTLY_VERSION=nightly-2022-03-10
+
 RUN apt-get update \
-    && apt-get install -y vim nano git curl gcc ninja-build cmake libudev-dev \
-    python3 python3-pip libusb-1.0-0 libssl-dev pkg-config libtinfo5 clang \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get install -y git curl ninja-build clang libudev-dev \
+    python3 python3-pip libusb-1.0-0 libssl-dev pkg-config libtinfo5 \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
 RUN adduser --disabled-password --gecos "" ${CONTAINER_USER}
 USER ${CONTAINER_USER}
 WORKDIR /home/${CONTAINER_USER}
 ENV PATH=${PATH}:$HOME/.cargo/bin
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-    --default-toolchain ${NIGHTLY_VERSION} -y \
+    --default-toolchain ${NIGHTLY_VERSION} -y --profile minimal \
     && $HOME/.cargo/bin/rustup component add rust-src --toolchain ${NIGHTLY_VERSION} \
-    && $HOME/.cargo/bin/rustup target add riscv32i-unknown-none-elf \
-    && $HOME/.cargo/bin/cargo install cargo-generate cargo-espflash espmonitor bindgen ldproxy
+    && $HOME/.cargo/bin/rustup target add riscv32i-unknown-none-elf
+
+RUN $HOME/.cargo/bin/cargo install cargo-generate cargo-espflash espmonitor bindgen ldproxy
+
 ENV ESP_BOARD=esp32c3
 ENV ESP_IDF_VERSION=release/v4.4
 RUN mkdir -p .espressif/frameworks/ \
@@ -27,4 +33,5 @@ RUN mkdir -p .espressif/frameworks/ \
     && .espressif/frameworks/esp-idf-v4.4/install.sh ${ESP_BOARD} \
     && rm -rf .espressif/dist \
     && rm -rf .espressif/frameworks/esp-idf-v4.4/docs
+
 CMD "/bin/bash"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,8 @@ ENV LANG=C.UTF-8
 ARG CONTAINER_USER=esp
 ARG CONTAINER_GROUP=esp
 ARG NIGHTLY_VERSION=nightly-2022-03-10
+ARG ESP_IDF_VERSION=release/v4.4
+ARG ESP_BOARD=esp32c3
 
 RUN apt-get update \
     && apt-get install -y git curl ninja-build clang libudev-dev \
@@ -22,16 +24,21 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
     && $HOME/.cargo/bin/rustup component add rust-src --toolchain ${NIGHTLY_VERSION} \
     && $HOME/.cargo/bin/rustup target add riscv32i-unknown-none-elf
 
-RUN $HOME/.cargo/bin/cargo install cargo-generate cargo-espflash espmonitor bindgen ldproxy
+RUN $HOME/.cargo/bin/cargo install cargo-espflash espmonitor bindgen ldproxy
 
-ENV ESP_BOARD=esp32c3
-ENV ESP_IDF_VERSION=release/v4.4
 RUN mkdir -p .espressif/frameworks/ \
     && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \
     --recursive https://github.com/espressif/esp-idf.git \
     .espressif/frameworks/esp-idf-v4.4 \
+    && python3 .espressif/frameworks/esp-idf-v4.4/tools/idf_tools.py install cmake \
     && .espressif/frameworks/esp-idf-v4.4/install.sh ${ESP_BOARD} \
     && rm -rf .espressif/dist \
-    && rm -rf .espressif/frameworks/esp-idf-v4.4/docs
+    && rm -rf .espressif/frameworks/esp-idf-v4.4/docs \
+    && rm -rf .espressif/frameworks/esp-idf-v4.4/examples \
+    && rm -rf .espressif/frameworks/esp-idf-v4.4/tools/esp_app_trace \
+    && rm -rf .espressif/frameworks/esp-idf-v4.4/tools/test_idf_size
+
+ENV IDF_TOOLS_PATH=/home/${CONTAINER_USER}/.espressif
+RUN echo "source /home/${CONTAINER_USER}/.espressif/frameworks/esp-idf-v4.4/export.sh > /dev/null 2>&1" >> ~/.bashrc
 
 CMD "/bin/bash"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "args": {
       "NIGHTLY_VERSION": "nightly-2022-03-10",
-      "CONTAINER_USER": "esp"
+      "CONTAINER_USER": "root"
     }
   },
   "settings": {
@@ -18,17 +18,17 @@
     },
     "rust-analyzer.checkOnSave.command": "clippy",
     "[rust]": {
-      "editor.defaultFormatter": "matklad.rust-analyzer"
-    },
+      "editor.defaultFormatter": "rust-lang.rust"
+    }
   },
   "extensions": [
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     "tamasfe.even-better-toml",
     "vadimcn.vscode-lldb",
     "serayuzgur.crates",
     "mutantdino.resourcemonitor",
-    "yzhang.markdown-all-in-one",
+    "yzhang.markdown-all-in-one"
   ],
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/esp/workspace,type=bind,consistency=cached",
-  "workspaceFolder": "/home/esp/workspace/"
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "NIGHTLY_VERSION": "nightly-2022-03-10",
-      "CONTAINER_USER": "root"
+      "NIGHTLY_VERSION": "nightly-2022-03-10"
     }
   },
   "settings": {
@@ -18,7 +17,7 @@
     },
     "rust-analyzer.checkOnSave.command": "clippy",
     "[rust]": {
-      "editor.defaultFormatter": "rust-lang.rust"
+      "editor.defaultFormatter": "rust-lang.rust-analyzer"
     }
   },
   "extensions": [
@@ -29,6 +28,7 @@
     "mutantdino.resourcemonitor",
     "yzhang.markdown-all-in-one"
   ],
+  "remoteUser": "root",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -2,7 +2,7 @@
 
 set -ef
 
-WORK_DIR=$HOME/workspace
+WORK_DIR=/workspace
 
 echo "Compiling all exercises & library crates"
 for file in $(find ${WORK_DIR} -name "Cargo.toml")

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,22 +2,19 @@
 name: Build Docker Image
 
 on:
-  pull_request:
-    paths:
-      - '!book/**'
-    branches:
-      - main
   push:
-    paths:
-      - '!book/**'
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "book/"
 
 jobs:
   # To avoid uploading the Docker image to a registry yet
   # the image is built here & immediately used to test all exercises in.
   # TODO at a later point split that into separate jobs
   build_image_and_test:
+    name: Build & test Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,5 +1,5 @@
 ---
-name: Build Docker Image
+name: Docker Image
 
 on:
   push:
@@ -14,7 +14,7 @@ jobs:
   # the image is built here & immediately used to test all exercises in.
   # TODO at a later point split that into separate jobs
   build_image_and_test:
-    name: Build & test Docker image
+    name: Build & test image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -26,4 +26,4 @@ jobs:
       - name: Test code examples in Docker image
         run: |
           docker run --user esp --mount type=bind,source="$(pwd)",target=/home/esp/workspace,consistency=cached \
-                 --rm -it esp:latest /bin/bash /home/esp/workspace/.devcontainer/test.sh
+                 --rm -i esp:latest /bin/bash /home/esp/workspace/.devcontainer/test.sh

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,5 +25,5 @@ jobs:
 
       - name: Test code examples in Docker image
         run: |
-          docker run --user esp --mount type=bind,source="$(pwd)",target=/home/esp/workspace,consistency=cached \
-                 --rm -i esp:latest /bin/bash /home/esp/workspace/.devcontainer/test.sh
+          docker run --mount type=bind,source="$(pwd)",target=/workspace,consistency=cached \
+                 --rm esp:latest /bin/bash /workspace/.devcontainer/test.sh

--- a/book/src/02_2_software.md
+++ b/book/src/02_2_software.md
@@ -94,11 +94,11 @@ Building the image takes a while depending on the OS & hardware (20-30 minutes).
 To start the new Docker container run:
 
 ```console
-$ docker run --user esp --mount type=bind,source="$(pwd)",target=/home/esp/workspace,consistency=cached -it esp /bin/bash
+$ docker run --mount type=bind,source="$(pwd)",target=/workspace,consistency=cached -it esp /bin/bash
 ```
 
 This starts an interactive shell in the Docker container. It also mounts the local repository to a folder
-named `/home/esp/workspace` inside the container. Changes to the project on the host system are reflected inside the container & vice versa.
+named `/workspace` inside the container. Changes to the project on the host system are reflected inside the container & vice versa.
 
 Using this Docker setup requires certain commands to run inside the container, while other have to be executed on the host system.
 It's recommended to keep two terminals open, one connected to the Docker container, one on the host system.


### PR DESCRIPTION
This PR fixes the Github CI workflow to build the Docker image in `.devcontainer/Dockerfile`. The Docker image is now built fully, all Rust projects are compiled within the image.

Due to a few restrictions when building a [Docker image using Github Actions](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions), the `Dockerfile` has been updated to avoid issues with `USER` & `WORKDIR` instructions.

* adjust `Dockerfile` to work on Github CI & as a VS Code devcontainer
* fix VS Code devcontainer config to set workspace & user
* update Github CI workflow to build Docker image & compile Rust projects
* reduce Docker image size, use `bullseye-slim` base image, remove unnecessary packages
* update instructions in material