### PR TITLE
Remove warnings

### DIFF
--- a/advanced/button-interrupt/solution/src/main_led.rs
+++ b/advanced/button-interrupt/solution/src/main_led.rs
@@ -84,6 +84,7 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
+#[allow(unused)]
 fn random_light(led: &mut WS2812RMT) {
     let mut color = RGB8::new(0, 0, 0);
     unsafe {

--- a/advanced/i2c-driver/solution/src/imc42670p.rs
+++ b/advanced/i2c-driver/solution/src/imc42670p.rs
@@ -1,5 +1,4 @@
 #![deny(unsafe_code)]
-#![no_std]
 
 use embedded_hal::blocking::i2c;
 
@@ -42,6 +41,7 @@ where
 
     /// Writes into a register
     /// This method is not public as it is only needed inside this file
+    #[allow(unused)]
     fn write_register(&mut self, register: Register, value: u8) -> Result<(), E> {
         let byte = value as u8;
         self.i2c

--- a/common/lib/esp32-c3-dkc02-bsc/src/temp_sensor.rs
+++ b/common/lib/esp32-c3-dkc02-bsc/src/temp_sensor.rs
@@ -6,6 +6,7 @@ const ADC_FACTOR: f32 = 0.4386;
 const DAC_FACTOR: f32 = 27.88;
 const _SYS_OFFSET: f32 = 20.52;
 
+#[allow(unused)]
 enum DacOffset {
     L0 = 5,  /*< offset = -2, measure range: 50℃ ~ 125℃, error < 3℃. */
     L1 = 7,  /*< offset = -1, measure range: 20℃ ~ 100℃, error < 2℃. */
@@ -31,11 +32,14 @@ impl DacOffset {
         }
     }
 }
+
+#[allow(unused)]
 struct SensorConfig {
     dac_offset: DacOffset,
     clock_divider: u8,
 }
 
+#[allow(unused)]
 impl SensorConfig {
     fn new(dac_offset: DacOffset, clock_divider: u8) -> Self {
         Self {


### PR DESCRIPTION
Removes warnings when building solutions. (Exercises should build but their code is incomplete. Therefore warnings can happen.)