### PR TITLE
Change pin number of (re-added) addressable LED.

### DIFF
--- a/common/lib/esp32-c3-dkc02-bsc/src/led.rs
+++ b/common/lib/esp32-c3-dkc02-bsc/src/led.rs
@@ -106,7 +106,7 @@ impl WS2812RMT {
         let config = rmt_config_t {
             rmt_mode: rmt_mode_t_RMT_MODE_TX,
             channel: 0,
-            gpio_num: 7,
+            gpio_num: 2,
             clk_div: 2,
             mem_block_num: 1,
             flags: 0,


### PR DESCRIPTION
The addressable LED was removed and then added back in again. To make the `button-interrupt` `main_led.rs` solution work again, the pin is changed.