### PR TITLE
Use tag instead of release branch

### DIFF
--- a/advanced/button-interrupt/exercise/.cargo/config.toml
+++ b/advanced/button-interrupt/exercise/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/advanced/button-interrupt/solution/.cargo/config.toml
+++ b/advanced/button-interrupt/solution/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/advanced/i2c-driver/solution/.cargo/config.toml
+++ b/advanced/i2c-driver/solution/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/advanced/i2c-sensor-reading/solution/.cargo/config.toml
+++ b/advanced/i2c-sensor-reading/solution/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/common/lib/esp32-c3-dkc02-bsc/.cargo/config.toml
+++ b/common/lib/esp32-c3-dkc02-bsc/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/hardware-check/.cargo/config.toml
+++ b/intro/hardware-check/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/http-client/exercise/.cargo/config.toml
+++ b/intro/http-client/exercise/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/http-client/solution/.cargo/config.toml
+++ b/intro/http-client/solution/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/http-server/exercise/.cargo/config.toml
+++ b/intro/http-server/exercise/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/http-server/solution/.cargo/config.toml
+++ b/intro/http-server/solution/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/mqtt/exercise/.cargo/config.toml
+++ b/intro/mqtt/exercise/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 

--- a/intro/mqtt/solution/.cargo/config.toml
+++ b/intro/mqtt/solution/.cargo/config.toml
@@ -28,7 +28,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF upcoming (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
+ESP_IDF_VERSION = { value = "tag:v4.4.1" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
 #ESP_IDF_VERSION = { value = "master" }
 


### PR DESCRIPTION
The release branch can be updated causing inconsistencies among different users depending on when they clone the repo. Safer to use release tags.