### PR TITLE
Add wokwi simulation and web flashing support.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
 
 RUN $HOME/.cargo/bin/cargo install cargo-espflash ldproxy \
     && $HOME/.cargo/bin/cargo install web-flash --git https://github.com/bjoernQ/esp-web-flash-server \
-    && RUSTFLAGS="--cfg tokio_unstable" cargo install wokwi-server --git https://github.com/MabezDev/wokwi-server --locked
+    && RUSTFLAGS="--cfg tokio_unstable" $HOME/.cargo/bin/cargo install wokwi-server --git https://github.com/MabezDev/wokwi-server --locked
 
 RUN mkdir -p ${HOME}/.espressif/frameworks/ \
     && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
     && $HOME/.cargo/bin/rustup component add rust-src --toolchain ${NIGHTLY_VERSION} \
     && $HOME/.cargo/bin/rustup target add riscv32imc-unknown-none-elf
 
-RUN $HOME/.cargo/bin/cargo install cargo-espflash ldproxy
+RUN $HOME/.cargo/bin/cargo install cargo-espflash ldproxy \
+    && $HOME/.cargo/bin/cargo install web-flash --git https://github.com/bjoernQ/esp-web-flash-server \
+    && RUSTFLAGS="--cfg tokio_unstable" cargo install wokwi-server --git https://github.com/MabezDev/wokwi-server --locked
 
 RUN mkdir -p ${HOME}/.espressif/frameworks/ \
     && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ARG ESP_IDF_VERSION=v4.4.1
 ARG ESP_BOARD=esp32c3
 
 RUN apt-get update \
-    && apt-get install -y git curl ninja-build clang libudev-dev \
+    && apt-get install -y git curl ninja-build clang libudev-dev libpython2.7 \
     python3 python3-pip libusb-1.0-0 libssl-dev pkg-config libtinfo5 \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/library-scripts

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,14 @@
     "vadimcn.vscode-lldb",
     "serayuzgur.crates",
     "mutantdino.resourcemonitor",
-    "yzhang.markdown-all-in-one"
+    "yzhang.markdown-all-in-one",
+    "webfreak.debug",
+    "actboy168.tasks"
+  ],
+  "forwardPorts": [
+    9012,
+    9333,
+    8000
   ],
   "remoteUser": "root",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -16,7 +16,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
     --default-toolchain ${NIGHTLY_VERSION} -y \
     && $HOME/.cargo/bin/rustup component add rust-src --toolchain ${NIGHTLY_VERSION} \
     && $HOME/.cargo/bin/rustup target add riscv32imc-unknown-none-elf \
-    && $HOME/.cargo/bin/cargo install cargo-espflash ldproxy
+    && $HOME/.cargo/bin/cargo install cargo-espflash ldproxy \
+    && $HOME/.cargo/bin/cargo install web-flash --git https://github.com/bjoernQ/esp-web-flash-server \
+    && RUSTFLAGS="--cfg tokio_unstable" cargo install wokwi-server --git https://github.com/MabezDev/wokwi-server --locked
 RUN mkdir -p ${HOME}/.espressif/frameworks/ \
     && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \
     --recursive https://github.com/espressif/esp-idf.git \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,15 +3,21 @@ image:
 tasks:
  - name: Setup environment variables for ESP-IDF
    command: |
-     source /home/gitpod/.espressif/frameworks/esp-idf-v4.4/export.sh > /dev/null 2>&1
+     source /home/gitpod/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1
 vscode:
   extensions:
     - matklad.rust-analyzer
     - tamasfe.even-better-toml
-    - vadimcn.vscode-lldb
     - anwar.resourcemonitor
     - yzhang.markdown-all-in-one
+    - webfreak.debug
+    - actboy168.tasks
     - serayuzgur.crates
 ports:
   - port: 9012
     visibility: public
+  - port: 9333
+    visibility: public
+  - port: 8000
+    visibility: public
+    onOpen: open-browser

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,11 @@
       "type": "gdb",
       "request": "attach",
       "name": "Wokwi Debug",
-      "executable":"${workspaceFolder}/target/riscv32imc-esp-espidf/debug/esp_tra",
+      // TODO Update executable path to the project to be debugged
+      "executable":"${workspaceFolder}/intro/hardware-check/target/riscv32imc-esp-espidf/debug/hardware-check",
       "target": "localhost:9333",
       "remote": true,
-      "gdbpath":"/home/${input:user}/.espressif/tools/riscv32-esp-elf/esp-2021r2-patch3-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-gdb",
+      "gdbpath":"${input:user}/.espressif/tools/riscv32-esp-elf/esp-2021r2-patch3-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-gdb",
       "cwd": "${workspaceRoot}",
       "stopAtConnect": true,
       "valuesFormatting": "parseText"
@@ -18,10 +19,10 @@
     {
       "type": "pickString",
       "id": "user",
-      "description": "Select the user: esp for VsCode and Codespaces and gitpod for Gitpod:",
+      "description": "Select the user: /root for VsCode and GH Codespaces and /home/gitpod for Gitpod:",
       "options": [
-        "esp",
-        "gitpod"
+        "/root",
+        "/home/gitpod"
       ],
       "default": "esp"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "gdb",
+      "request": "attach",
+      "name": "Wokwi Debug",
+      "executable":"${workspaceFolder}/target/riscv32imc-esp-espidf/debug/esp_tra",
+      "target": "localhost:9333",
+      "remote": true,
+      "gdbpath":"/home/${input:user}/.espressif/tools/riscv32-esp-elf/esp-2021r2-patch3-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-gdb",
+      "cwd": "${workspaceRoot}",
+      "stopAtConnect": true,
+      "valuesFormatting": "parseText"
+    }
+  ],
+  "inputs": [
+    {
+      "type": "pickString",
+      "id": "user",
+      "description": "Select the user: esp for VsCode and Codespaces and gitpod for Gitpod:",
+      "options": [
+        "esp",
+        "gitpod"
+      ],
+      "default": "esp"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,73 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/build.sh ${input:buildMode}",
+      "options": {
+        "cwd": "${workspaceFolder}/${input:project}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Build & Flash",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/flash.sh ${input:buildMode} ${input:project}",
+      "options": {
+        "cwd": "${workspaceFolder}/${input:project}"
+      },
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Build & Run Wokwi",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/run-wokwi.sh ${input:buildMode} ${input:project}",
+      "options": {
+        "cwd": "${workspaceFolder}/${input:project}"
+      },
+      "group": {
+        "kind": "test",
+        "isDefault": false
+      }
+    },
+  ],
+  "inputs": [
+    {
+      "type": "pickString",
+      "id": "buildMode",
+      "description": "Select the build mode:",
+      "options": [
+        "release",
+        "debug"
+      ],
+      "default": "release"
+    },
+    {
+      "type": "pickString",
+      "id": "project",
+      "description": "Select the build project:",
+      "options": [
+        "advanced/button-interrupt/exercise",
+        "advanced/button-interrupt/solution",
+        "advanced/i2c-driver/solution",
+        "advanced/i2c-sensor-reading/solution",
+        "intro/hardware-check",
+        "intro/http-client/exercise",
+        "intro/http-client/solution",
+        "intro/http-server/exercise",
+        "intro/http-server/solution",
+        "intro/mqtt/exercise",
+        "intro/mqtt/solution",
+        "intro/mqtt/host-client",
+      ],
+      "default": "release"
+    }
+  ]
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Gitpod and VsCode Codespaces tasks do not source the user environment
+if [ "${USER}" == "gitpod" ]; then
+    which idf.py >/dev/null || {
+        source ~/export-esp.sh >/dev/null 2>&1
+    }
+elif [ "${CODESPACE_NAME}" != "" ]; then
+    which idf.py >/dev/null || {
+        source ~/export-esp.sh >/dev/null 2>&1
+    }
+fi
+
+case "$1" in
+"" | "release")
+    cargo build --release
+    ;;
+"debug")
+    cargo build
+    ;;
+*)
+    echo "Wrong argument. Only \"debug\"/\"release\" arguments are supported"
+    exit 1
+    ;;
+esac

--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+BUILD_MODE=""
+case "$1" in
+    ""|"release")
+        bash /workspace/scripts/build.sh
+        BUILD_MODE="release"
+        ;;
+    "debug")
+        bash /workspace/scripts/build.sh debug
+        BUILD_MODE="debug"
+        ;;
+    *)
+        echo "Wrong argument. Only \"debug\"/\"release\" arguments are supported"
+        exit 1;;
+esac
+
+export ESP_ARCH=riscv32imc-esp-espidf
+
+ELF_FILE=""
+if [[ "$2" == "intro/hardware-check" ]]; then
+    ELF_FILE="hardware-check"
+elif [[ "$2" =~ "intro/http-client" ]]; then
+    ELF_FILE="http-client"
+elif [[ "$2" =~ "intro/http-server" ]]; then
+    ELF_FILE="http-server"
+elif [[ "$2" =~ "intro/mqtt" ]]; then
+    ELF_FILE="mqtt"
+elif [[ "$2" =~ "advanced/button-interrupt" ]]; then
+    ELF_FILE="button-interrupt"
+elif [[ "$2" =~ "advanced/i2c-driver" ]]; then
+    ELF_FILE="i2c-driver-exercise"
+elif [[ "$2" =~ "advanced/i2c-sensor-reading" ]]; then
+    ELF_FILE="i2c-sensor-exercise"
+fi
+web-flash --chip esp32c3 target/${ESP_ARCH}/${BUILD_MODE}/${ELF_FILE}

--- a/scripts/run-wokwi.sh
+++ b/scripts/run-wokwi.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+BUILD_MODE=""
+case "$1" in
+    ""|"release")
+        bash /workspace/scripts/build.sh
+        BUILD_MODE="release"
+        ;;
+    "debug")
+        bash /workspace/scripts/build.sh debug
+        BUILD_MODE="debug"
+        ;;
+    *)
+        echo "Wrong argument. Only \"debug\"/\"release\" arguments are supported"
+        exit 1;;
+esac
+
+if [ "${USER}" == "gitpod" ];then
+    gp_url=$(gp url 9012)
+    echo "gp_url=${gp_url}"
+    export WOKWI_HOST=${gp_url:8}
+elif [ "${CODESPACE_NAME}" != "" ];then
+    export WOKWI_HOST=${CODESPACE_NAME}-9012.githubpreview.dev
+fi
+
+export ESP_ARCH=riscv32imc-esp-espidf
+
+WOKWI_PROJECT_ID=""
+ELF_FILE=""
+if [[ "$2" == "intro/hardware-check" ]]; then
+    WOKWI_PROJECT_ID="334080865809203794"
+    ELF_FILE="hardware-check"
+elif [[ "$2" =~ "intro/http-client" ]]; then
+    WOKWI_PROJECT_ID="333372159510446675"
+    ELF_FILE="http-client"
+elif [[ "$2" =~ "intro/http-server" ]]; then
+    WOKWI_PROJECT_ID="334083021941506642"
+    ELF_FILE="http-server"
+elif [[ "$2" =~ "intro/mqtt" ]]; then
+    WOKWI_PROJECT_ID="333374379294458451"
+    ELF_FILE="mqtt"
+elif [[ "$2" =~ "advanced/button-interrupt" ]]; then
+    WOKWI_PROJECT_ID="333374799393849940"
+    ELF_FILE="button-interrupt"
+elif [[ "$2" =~ "advanced/i2c-driver" ]]; then
+    WOKWI_PROJECT_ID="333375074521317970"
+    ELF_FILE="i2c-driver-exercise"
+elif [[ "$2" =~ "advanced/i2c-sensor-reading" ]]; then
+    WOKWI_PROJECT_ID="333375908055351891"
+    ELF_FILE="i2c-sensor-exercise"
+fi
+
+
+if [ "${WOKWI_PROJECT_ID}" == "" ]; then
+    wokwi-server --chip esp32c3 $2/target/${ESP_ARCH}/${BUILD_MODE}/${ELF_FILE}
+else
+    wokwi-server --chip esp32c3 --id ${WOKWI_PROJECT_ID} target/${ESP_ARCH}/${BUILD_MODE}/${ELF_FILE}
+fi


### PR DESCRIPTION
- Wokwi simulation: Using [wokwi-server](https://github.com/MabezDev/wokwi-server) you can simulate the projects.
  - Wokwi also supports GDB debugging, so I included` launch.json` with the necessary configuration to debug the project from devcontainers (although it requires the user to set the path to the project to be debugged).
- When using devcontainers, we cant flash with `cargo-espflash` so I added [`web-flash`](https://github.com/bjoernQ/esp-web-flash-server)  to flash real devices from devcontainers!
- Add some vscode task to build, flash, and run Wokwi simualtions from devcontainers