### PR TITLE
updating CI to **not** trigger code checks for book updates

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths-ignore:
       - "book/"
+      - "book/**"
 
 jobs:
   # To avoid uploading the Docker image to a registry yet


### PR DESCRIPTION
Any updates to the book is triggering code checks now (25 minutes ish).